### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,38 +1,38 @@
 # Syntax Coloring Map For ModbusIP_ESP8266
 
 # Datatypes (KEYWORD1)
-ModbusIP        KEYWORD1
-ModbusMasterIP  KEYWORD1
-ModbusIP_ESP8266 KEYWORD1
+ModbusIP	KEYWORD1
+ModbusMasterIP	KEYWORD1
+ModbusIP_ESP8266	KEYWORD1
 
 # Methods and Functions (KEYWORD2)
-begin          	KEYWORD2
-task            KEYWORD2
-onConnect		KEYWORD2
-cbEnable        KEYWORD2
-cbDisable       KEYWORD2
-eventSource     KEYWORD2
-onGetCoil		KEYWORD2
-onSetCoil		KEYWORD2
-onGetHreg		KEYWORD2
-onSetHreg		KEYWORD2
-onGetIreg		KEYWORD2
-onSetIreg		KEYWORD2
-onGetIsts		KEYWORD2
-onSetIsts		KEYWORD2
-addCoil         KEYWORD2
-addIsts         KEYWORD2
-addIreg         KEYWORD2
-addHreg         KEYWORD2
-Coil            KEYWORD2
-Ists            KEYWORD2
-Ireg            KEYWORD2
-Hreg            KEYWORD2
+begin	KEYWORD2
+task	KEYWORD2
+onConnect	KEYWORD2
+cbEnable	KEYWORD2
+cbDisable	KEYWORD2
+eventSource	KEYWORD2
+onGetCoil	KEYWORD2
+onSetCoil	KEYWORD2
+onGetHreg	KEYWORD2
+onSetHreg	KEYWORD2
+onGetIreg	KEYWORD2
+onSetIreg	KEYWORD2
+onGetIsts	KEYWORD2
+onSetIsts	KEYWORD2
+addCoil	KEYWORD2
+addIsts	KEYWORD2
+addIreg	KEYWORD2
+addHreg	KEYWORD2
+Coil	KEYWORD2
+Ists	KEYWORD2
+Ireg	KEYWORD2
+Hreg	KEYWORD2
 
 # Constants and Macros (LITERAL1)
-BIT_VAL			LITERAL1
-BIT_BOOL		LITERAL1
-COIL_VAL		LITERAL1
-COIL_BOOL		LITERAL1
-ISTS_VAL		LITERAL1
-ISTS_BOOL		LITERAL1
+BIT_VAL	LITERAL1
+BIT_BOOL	LITERAL1
+COIL_VAL	LITERAL1
+COIL_BOOL	LITERAL1
+ISTS_VAL	LITERAL1
+ISTS_BOOL	LITERAL1


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords