### PR TITLE
Support non ESP devices

### DIFF
--- a/examples/RTU-master/RTU-Master.ino
+++ b/examples/RTU-master/RTU-Master.ino
@@ -1,32 +1,51 @@
 /*
   ModbusRTU ESP8266/ESP32
   Read multiple coils from slave device example
-  
+
   (c)2019 Alexander Emelianov (a.m.emelianov@gmail.com)
   https://github.com/emelianov/modbus-esp8266
+
+  modified 13 May 2020
+  by brainelectronics
+
   This code is licensed under the BSD New License. See LICENSE.txt for more info.
 */
 
 #include <ModbusRTU.h>
-#ifdef ESP8266
+#if defined(ESP8266)
  #include <SoftwareSerial.h>
- SoftwareSerial S(D1, D2, false, 256);
+ // SoftwareSerial S(D1, D2, false, 256);
+
+ // receivePin, transmitPin, inverse_logic, bufSize, isrBufSize
+ // connect RX to D2 (GPIO4, Arduino pin 4), TX to D1 (GPIO5, Arduino pin 4)
+ SoftwareSerial S(4, 5);
 #endif
 
 ModbusRTU mb;
 
 bool cbWrite(Modbus::ResultCode event, uint16_t transactionId, void* data) {
+#ifdef ESP8266
   Serial.printf_P("Request result: 0x%02X, Mem: %d\n", event, ESP.getFreeHeap());
+#elif ESP32
+  Serial.printf_P("Request result: 0x%02X, Mem: %d\n", event, ESP.getFreeHeap());
+#else
+  Serial.print("Request result: 0x");
+  Serial.print(event, HEX);
+#endif
   return true;
 }
 
 void setup() {
   Serial.begin(115200);
- #ifdef ESP8266
+ #if defined(ESP8266)
   S.begin(9600, SWSERIAL_8N1);
   mb.begin(&S);
+ #elif defined(ESP32)
+  Serial1.begin(9600, SERIAL_8N1);
+  mb.begin(&Serial1);
  #else
-  Serial1.begin(9600, SERIAL_8N1, 17, 18);
+  Serial1.begin(9600, SERIAL_8N1);
+  mb.setBaudrate(9600);
   mb.begin(&Serial1);
  #endif
   mb.master();

--- a/examples/RTU-slave/RTU-slave.ino
+++ b/examples/RTU-slave/RTU-slave.ino
@@ -1,9 +1,14 @@
 /*
   ModbusRTU ESP8266/ESP32
   Simple slave example
-  
+
   (c)2019 Alexander Emelianov (a.m.emelianov@gmail.com)
   https://github.com/emelianov/modbus-esp8266
+
+  modified 13 May 2020
+  by brainelectronics
+
+  This code is licensed under the BSD New License. See LICENSE.txt for more info.
 */
 
 #include <ModbusRTU.h>
@@ -14,8 +19,13 @@
 ModbusRTU mb;
 
 void setup() {
-  Serial.begin(9600, SERIAL_8N1)
+  Serial.begin(9600, SERIAL_8N1);
+#if defined(ESP32) || defined(ESP8266)
   mb.begin(&Serial);
+#else
+  mb.setBaudrate(9600);
+  mb.begin(&Serial);
+#endif
   mb.slave(SLAVE_ID);
   mb.addHreg(REGN);
   mb.Hreg(REGN, 100);

--- a/src/ModbusIP_ESP8266.cpp
+++ b/src/ModbusIP_ESP8266.cpp
@@ -3,6 +3,8 @@
     Copyright (C) 2014 Andr� Sarmento Barbosa
                   2017-2019 Alexander Emelianov (a.m.emelianov@gmail.com)
 */
+#if defined(ESP32) || defined(ESP8266)
+
 #include "ModbusIP_ESP8266.h"
 
 ModbusIP::ModbusIP() {
@@ -424,3 +426,5 @@ ModbusIP::~ModbusIP() {
 		client[i] = nullptr;
 	}
 }
+
+#endif

--- a/src/ModbusIP_ESP8266.h
+++ b/src/ModbusIP_ESP8266.h
@@ -5,6 +5,8 @@
 */
 #pragma once
 
+#if defined(ESP32) || defined(ESP8266)
+
 #include <Modbus.h>
 #ifdef ESP8266
  #include <ESP8266WiFi.h>
@@ -124,3 +126,5 @@ class ModbusIP : public Modbus {
 		cbTransaction cb = nullptr, uint8_t unit = MODBUSIP_UNIT);
 	*/
 };
+
+#endif

--- a/src/ModbusRTU.cpp
+++ b/src/ModbusRTU.cpp
@@ -49,11 +49,23 @@ bool ModbusRTU::begin(Stream* port) {
     return true;
 }
 
-bool ModbusRTU::begin(HardwareSerial* port, int16_t txPin) {
-	uint32_t baud = port->baudRate();
-	#if defined(ESP8266)
-	maxRegs = port->setRxBufferSize(MODBUS_MAX_FRAME) / 2 - 3;
-	#endif
+bool ModbusRTU::begin(HardwareSerial* port, uint32_t thisBaudrate, int16_t txPin) {
+    uint32_t baud = 0;
+    if (thisBaudrate > 0) {
+        baud = thisBaudrate;
+    }
+    else {
+    #if defined(ESP32) || defined(ESP8266)
+        // baudRate() only available with ESP32+ESP8266
+        baud = port->baudRate();
+    #else
+    #warning "Using default baudrate if not specified"
+        baud = 9600;
+    #endif
+    }
+    #if defined(ESP8266)
+    maxRegs = port->setRxBufferSize(MODBUS_MAX_FRAME) / 2 - 3;
+    #endif
     _port = port;
     _txPin = txPin;
     if (txPin >= 0) {

--- a/src/ModbusRTU.cpp
+++ b/src/ModbusRTU.cpp
@@ -43,7 +43,7 @@ uint16_t ModbusRTU::crc16(uint8_t address, uint8_t* frame, uint8_t pduLen) {
     return (CRCHi << 8) | CRCLo;
 }
 
-void ModbusRTU::setBaudrate(uint32 baud = -1) {
+void ModbusRTU::setBaudrate(uint32 baud) {
 	_baudrate = baud;
 }
 

--- a/src/ModbusRTU.cpp
+++ b/src/ModbusRTU.cpp
@@ -43,7 +43,7 @@ uint16_t ModbusRTU::crc16(uint8_t address, uint8_t* frame, uint8_t pduLen) {
     return (CRCHi << 8) | CRCLo;
 }
 
-void ModbusRTU::setBaudrate(uint32 baud) {
+void ModbusRTU::setBaudrate(uint32_t baud) {
 	_baudrate = baud;
 }
 

--- a/src/ModbusRTU.h
+++ b/src/ModbusRTU.h
@@ -48,7 +48,7 @@ class ModbusRTU : public Modbus {
 	 #if defined(ESP8266)
 	 	bool begin(SoftwareSerial* port, int16_t txPin=-1);
 	 #endif
-		bool begin(HardwareSerial* port, uint32_t thisBaudrate=-1, int16_t txPin=-1);
+		bool begin(HardwareSerial* port, int16_t txPin=-1);
 		bool begin(Stream* port);
         void task();
 		void master() { isMaster = true; };

--- a/src/ModbusRTU.h
+++ b/src/ModbusRTU.h
@@ -44,7 +44,7 @@ class ModbusRTU : public Modbus {
 		bool cleanup(); 	// Free clients if not connected and remove timedout transactions and transaction with forced events
 		uint16_t crc16(uint8_t address, uint8_t* frame, uint8_t pdulen);
     public:
-		void setBaudrate(uint32 baud = -1);
+		void setBaudrate(uint32_t baud = -1);
 	 #if defined(ESP8266)
 	 	bool begin(SoftwareSerial* port, int16_t txPin=-1);
 	 #endif

--- a/src/ModbusRTU.h
+++ b/src/ModbusRTU.h
@@ -23,6 +23,7 @@ class ModbusRTU : public Modbus {
     protected:
         Stream* _port;
         int16_t   _txPin = -1;
+        uint32_t _baudrate = -1;
 		unsigned int _t;	// inter-frame delay in mS
 		uint32_t t = 0;
 		bool isMaster = false;
@@ -43,6 +44,7 @@ class ModbusRTU : public Modbus {
 		bool cleanup(); 	// Free clients if not connected and remove timedout transactions and transaction with forced events
 		uint16_t crc16(uint8_t address, uint8_t* frame, uint8_t pdulen);
     public:
+		void setBaudrate(uint32 baud = -1);
 	 #if defined(ESP8266)
 	 	bool begin(SoftwareSerial* port, int16_t txPin=-1);
 	 #endif

--- a/src/ModbusRTU.h
+++ b/src/ModbusRTU.h
@@ -46,7 +46,7 @@ class ModbusRTU : public Modbus {
 	 #if defined(ESP8266)
 	 	bool begin(SoftwareSerial* port, int16_t txPin=-1);
 	 #endif
-	 	bool begin(HardwareSerial* port, int16_t txPin=-1);
+		bool begin(HardwareSerial* port, uint32_t thisBaudrate=-1, int16_t txPin=-1);
 		bool begin(Stream* port);
         void task();
 		void master() { isMaster = true; };


### PR DESCRIPTION
By this small fix it is possible to compile and use the lib for non ESP devices like STM32F103 or Arduino Uno. Of course only ModbusRTU is usable.