### PR TITLE
fix warning

### DIFF
--- a/src/Modbus.cpp
+++ b/src/Modbus.cpp
@@ -123,9 +123,9 @@ bool Modbus::removeReg(TAddress address, uint16_t numregs) {
 bool Modbus::addReg(TAddress address, uint16_t* value, uint16_t numregs) {
     if (0xFFFF - address.address < numregs)
         numregs = 0xFFFF - address.address;
-	for (uint16_t k = 0; k < numregs; k++)
-		addReg(address + k, value[k]);
-	return true;
+    for (uint16_t k = 0; k < numregs; k++)
+        addReg(address + k, value[k]);
+    return true;
 }
 
 void Modbus::slavePDU(uint8_t* frame) {

--- a/src/Modbus.cpp
+++ b/src/Modbus.cpp
@@ -121,13 +121,11 @@ bool Modbus::removeReg(TAddress address, uint16_t numregs) {
 }
 
 bool Modbus::addReg(TAddress address, uint16_t* value, uint16_t numregs) {
-    if (0xFFFF - address.address < numregs) {
+    if (0xFFFF - address.address < numregs)
         numregs = 0xFFFF - address.address;
-    }
-    for (uint16_t k = 0; k < numregs; k++) {
-        addReg(address + k, value[k]);
-    }
-    return true;
+	for (uint16_t k = 0; k < numregs; k++)
+		addReg(address + k, value[k]);
+	return true;
 }
 
 void Modbus::slavePDU(uint8_t* frame) {

--- a/src/Modbus.cpp
+++ b/src/Modbus.cpp
@@ -121,11 +121,13 @@ bool Modbus::removeReg(TAddress address, uint16_t numregs) {
 }
 
 bool Modbus::addReg(TAddress address, uint16_t* value, uint16_t numregs) {
-    if (0xFFFF - address.address < numregs)
+    if (0xFFFF - address.address < numregs) {
         numregs = 0xFFFF - address.address;
-	for (uint16_t k = 0; k < numregs; k++)
-		addReg(address + k, value[k]);
-	return true;
+    }
+    for (uint16_t k = 0; k < numregs; k++) {
+        addReg(address + k, value[k]);
+    }
+    return true;
 }
 
 void Modbus::slavePDU(uint8_t* frame) {

--- a/src/ModbusRTU.cpp
+++ b/src/ModbusRTU.cpp
@@ -82,8 +82,8 @@ bool ModbusRTUTemplate::rawSend(uint8_t slaveId, uint8_t* frame, uint8_t len) {
     _port->flush();
     if (_txPin >= 0)
         digitalWrite(_txPin, _direct?LOW:HIGH);
-	//delay(_t);
-	return true;
+    //delay(_t);
+    return true;
 }
 
 uint16_t ModbusRTUTemplate::send(uint8_t slaveId, TAddress startreg, cbTransaction cb, uint8_t unit, uint8_t* data, bool waitResponse) {

--- a/src/ModbusRTU.cpp
+++ b/src/ModbusRTU.cpp
@@ -80,11 +80,10 @@ bool ModbusRTUTemplate::rawSend(uint8_t slaveId, uint8_t* frame, uint8_t len) {
     _port->write(newCrc >> 8);	//Send CRC
     _port->write(newCrc & 0xFF);//Send CRC
     _port->flush();
-    if (_txPin >= 0) {
+    if (_txPin >= 0)
         digitalWrite(_txPin, _direct?LOW:HIGH);
-    }
-    //delay(_t);
-    return true;
+	//delay(_t);
+	return true;
 }
 
 uint16_t ModbusRTUTemplate::send(uint8_t slaveId, TAddress startreg, cbTransaction cb, uint8_t unit, uint8_t* data, bool waitResponse) {

--- a/src/ModbusRTU.cpp
+++ b/src/ModbusRTU.cpp
@@ -80,10 +80,11 @@ bool ModbusRTUTemplate::rawSend(uint8_t slaveId, uint8_t* frame, uint8_t len) {
     _port->write(newCrc >> 8);	//Send CRC
     _port->write(newCrc & 0xFF);//Send CRC
     _port->flush();
-    if (_txPin >= 0)
+    if (_txPin >= 0) {
         digitalWrite(_txPin, _direct?LOW:HIGH);
-	//delay(_t);
-	return true;
+    }
+    //delay(_t);
+    return true;
 }
 
 uint16_t ModbusRTUTemplate::send(uint8_t slaveId, TAddress startreg, cbTransaction cb, uint8_t unit, uint8_t* data, bool waitResponse) {

--- a/src/ModbusTCPTemplate.h
+++ b/src/ModbusTCPTemplate.h
@@ -232,7 +232,7 @@ void ModbusTCPTemplate<SERVER, CLIENT>::task() {
 	for (n = 0; n < MODBUSIP_MAX_CLIENTS; n++) {
 		if (!tcpclient[n]) continue;
 		if (!tcpclient[n]->connected()) continue;
-		while (millis() - taskStart < MODBUSIP_MAX_READMS &&  tcpclient[n]->available() > sizeof(_MBAP)) {
+		while (millis() - taskStart < MODBUSIP_MAX_READMS &&  (unsigned int)tcpclient[n]->available() > sizeof(_MBAP)) {
 			tcpclient[n]->readBytes(_MBAP.raw, sizeof(_MBAP.raw));	// Get MBAP
 		
 			if (__swap_16(_MBAP.protocolId) != 0) {   // Check if MODBUSIP packet. __swap is usless there.

--- a/src/ModbusTCPTemplate.h
+++ b/src/ModbusTCPTemplate.h
@@ -232,7 +232,7 @@ void ModbusTCPTemplate<SERVER, CLIENT>::task() {
 	for (n = 0; n < MODBUSIP_MAX_CLIENTS; n++) {
 		if (!tcpclient[n]) continue;
 		if (!tcpclient[n]->connected()) continue;
-		while (millis() - taskStart < MODBUSIP_MAX_READMS &&  (unsigned int)tcpclient[n]->available() > sizeof(_MBAP)) {
+		while (millis() - taskStart < MODBUSIP_MAX_READMS &&  (size_t)tcpclient[n]->available() > sizeof(_MBAP)) {
 			tcpclient[n]->readBytes(_MBAP.raw, sizeof(_MBAP.raw));	// Get MBAP
 		
 			if (__swap_16(_MBAP.protocolId) != 0) {   // Check if MODBUSIP packet. __swap is usless there.


### PR DESCRIPTION
I got the warning below during build with platformio. This will fix it.
```bash
In file included from .pio\libdeps\d1\modbus-esp8266\src/ModbusTCP.h:15,
                 from .pio\libdeps\d1\modbus-esp8266\src/ModbusIP_ESP8266.h:9,
                 from C:/Users/hnm2abt/Documents/espota-test/src/main.ino:9:
.pio\libdeps\d1\modbus-esp8266\src/ModbusTCPTemplate.h: In instantiation of 'void ModbusTCPTemplate<SERVER, CLIENT>::task() [with SERVER = WiFiServerESP
C:/Users/hnm2abt/Documents/espota-test/src/main.ino:60:19:   required from here
.pio\libdeps\d1\modbus-esp8266\src/ModbusTCPTemplate.h:235:83: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned i
  235 |   while (millis() - taskStart < MODBUSIP_MAX_READMS &&  tcpclient[n]->available() > sizeof(_MBAP)) {
      |                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
```