### PR TITLE
Correct indentation

### DIFF
--- a/src/ModbusTCPTemplate.h
+++ b/src/ModbusTCPTemplate.h
@@ -262,7 +262,7 @@ void ModbusTCPTemplate<SERVER, CLIENT>::task() {
 			if (__swap_16(_MBAP.protocolId) != 0) {   // Check if MODBUSIP packet. __swap is usless there.
 				while (tcpclient[n]->available())	// Drop all incoming if wrong packet
 					tcpclient[n]->read();
-					continue;
+				continue;
 			}
 			_len = __swap_16(_MBAP.length);
 			_len--; // Do not count with last byte from MBAP


### PR DESCRIPTION
Hello, I've corrected a small compilation warning:

.../src/ModbusTCPTemplate.h:263:5: warning: this 'while' clause does not guard... [-Wmisleading-indentation]
  263 |     while (tcpclient[n]->available()) // Drop all incoming if wrong packet
      |       ^~~~~
.../src/ModbusTCPTemplate.h:265:6: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'while'
  265 |      continue;
      |      ^~~~~~~~

Have a good day :)