### PR TITLE
Update ModbusTCPTemplate.h

### DIFF
--- a/src/ModbusTCPTemplate.h
+++ b/src/ModbusTCPTemplate.h
@@ -484,7 +484,8 @@ int8_t ModbusTCPTemplate<SERVER, CLIENT>::getFreeClient() {
 template <class SERVER, class CLIENT>
 int8_t ModbusTCPTemplate<SERVER, CLIENT>::getSlave(IPAddress ip) {
 	for (uint8_t i = 0; i < MODBUSIP_MAX_CLIENTS; i++)
-		if (tcpclient[i] && tcpclient[i]->connected() && tcpclient[i]->remoteIP() == ip && !BIT_CHECK(tcpServerConnection, i))
+		//if (tcpclient[i] && tcpclient[i]->connected() && tcpclient[i]->remoteIP() == ip && !BIT_CHECK(tcpServerConnection, i))
+		if (tcpclient[i] && tcpclient[i]->connected() && !BIT_CHECK(tcpServerConnection, i)) //tcpclient[i]->remoteIP()
 			return i;
 	return -1;
 }


### PR DESCRIPTION
[modbus-esp8266/tree/master/examples/TLS/client ] will not work with [esp8266/Arduino/3.0.2]!
it only works with  [esp8266/Arduino/master] and the change below.



template <class SERVER, class CLIENT>
int8_t ModbusTCPTemplate<SERVER, CLIENT>::getSlave(IPAddress ip) {
	for (uint8_t i = 0; i < MODBUSIP_MAX_CLIENTS; i++)
		if (tcpclient[i] && tcpclient[i]->connected() && !BIT_CHECK(tcpServerConnection, i))
			return i;
	return -1;
}

tcpclient[i]->remoteIP()    returns no IP address!!!!!!!!