### PR TITLE
Uncomment the explicit stop() method call to allow sockets cleanups

### DIFF
--- a/src/ModbusTCPTemplate.h
+++ b/src/ModbusTCPTemplate.h
@@ -437,7 +437,7 @@ void ModbusTCPTemplate<SERVER, CLIENT>::cleanupConnections() {
 	for (uint8_t i = 0; i < MODBUSIP_MAX_CLIENTS; i++) {
 		if (tcpclient[i] && !tcpclient[i]->connected()) {
 			//IPAddress ip = tcpclient[i]->remoteIP();
-			//tcpclient[i]->stop();
+			tcpclient[i]->stop();
 			delete tcpclient[i];
 			tcpclient[i] = nullptr;
 			if (cbDisconnect && cbEnabled) 
@@ -546,7 +546,7 @@ bool ModbusTCPTemplate<SERVER, CLIENT>::disconnect(IPAddress ip) {
 		return false;
 	int8_t p = getSlave(ip);
 	if (p != -1) {
-		//tcpclient[p]->stop();
+		tcpclient[p]->stop();
 		delete tcpclient[p];
 		tcpclient[p] = nullptr;
 		return true;


### PR DESCRIPTION
This should allow w5xxx-based ethernet to clean up their sockets' states upon disconnection, preventing the server implementation to experience sockets starvation