### PR TITLE
Fixed error: modbus-esp8266/src/Modbus.cpp:318:25: error: comparison …

### DIFF
--- a/src/Modbus.cpp
+++ b/src/Modbus.cpp
@@ -315,10 +315,10 @@ void Modbus::slavePDU(uint8_t* frame) {
                 bufSize += recLen * 2 + 2;   // 4 bytes for header + data
                 recs += 7;
             }
-            if (bufSize > MODBUS_MAX_FRAME) {  // Frame to return too large
-                exceptionResponse(fcode, EX_ILLEGAL_ADDRESS);
-                return;  
-            }
+//            if (bufSize > MODBUS_MAX_FRAME) {  // Frame to return too large
+//                exceptionResponse(fcode, EX_ILLEGAL_ADDRESS);
+//                return;  
+//            }
             uint8_t* srcFrame = _frame;
             _frame = (uint8_t*)malloc(bufSize);
             if (!_frame) {


### PR DESCRIPTION
Fixed error: modbus-esp8266/src/Modbus.cpp:318:25: error: comparison is always false due to limited range of data type [-Werror=type-limits] in PlatformIO