### PR TITLE
- Fixed "responce" typo and other typos in doc and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For more information about Modbus see:
 
 ```diff
 // 4.1.1
-+ Protocol: Fix wrong error code responce on non-existent register
++ Protocol: Fix wrong error code response on non-existent register
 + ModbusTCP: Fix potential memory leak
 + API: cbEnable/cbDisable functionality extended
 + ESP-IDF: CMakeList.txt added
@@ -95,7 +95,7 @@ For more information about Modbus see:
 - Buffer/packet size limitation support
 - Slave/Server: slavePDU use early exit by return where possible
 - Master/Client: Check frame size against header data where possible
-- Master/Client: Additional responce data validation
+- Master/Client: Additional response data validation
 - Free global registers and callbacks on remove last Modbus instance
 - Test: push/pull functions
 - ModbusTCP: Refactor connect by dns name (using native implementation for ESP32 etc)

--- a/documentation/API.md
+++ b/documentation/API.md
@@ -55,21 +55,21 @@ bool begin(Stream* port);
 Assing Serial port. txEnablePin controls transmit enable for MAX-485. Pass txEnableDirect=false if txEnablePin uses inverse logic.
 
 ```c
-void setBaudrte(uint32 baud);
+void setBaudrate(uint32 baud);
 ```
 
 Set or override Serial baudrate. Must be called after .begin() for Non-ESP devices.
 
 ```c
 void server(uint8_t slaveId);
-void slave(uint8_t slaveId); //Depricated
+void slave(uint8_t slaveId); //Deprecated
 ```
 
 Select and initialize master or slave mode to work. Switching between modes is not supported. Call is not returning error in this case but behaviour is unpredictible.
 
 ```c
 uint8_t server();
-uint8_t slave(); //Depricated
+uint8_t slave(); //Deprecated
 ```
 
 Slave mode: Returns configured slave id. Master mode: Returns slave id for active request or 0 if no request in-progress.
@@ -77,7 +77,7 @@ Slave mode: Returns configured slave id. Master mode: Returns slave id for activ
 ## Modbus TCP Server specific API
 
 ```c
-void begin(); // Depricated. Use server() instead.
+void begin(); // Deprecated. Use server() instead.
 void slave(uint16_t port = MODBUSIP_PORT); // For compatibility with ModbusRTU calls. Typically may be replaced with server() call.
 void server(uint16_t port = MODBUSIP_PORT);
 ```

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -41,7 +41,7 @@ Modbus standard defines only two types of data: bit value and 16-bit value. All 
 
 ## Value not read after `readCoil`/`readHreg`/etc
 
-The library is designed to execute calls async way. That is `readHreg()` function just sends read request to Modbus server device and exits. Responce is processed (as suun as it's arrive) by `task()`. `task()` is also async and exits if data hasn't arrive yet.  
+The library is designed to execute calls async way. That is `readHreg()` function just sends read request to Modbus server device and exits. Response is processed (as suun as it's arrive) by `task()`. `task()` is also async and exits if data hasn't arrive yet.  
 
 ---
 

--- a/examples/Bridge/README.md
+++ b/examples/Bridge/README.md
@@ -18,15 +18,15 @@ Fullfunctional ModbusTCP to ModbusRTU bridge with on-device ModbusRTU simulator
 
 ```c
 uint16_t rawRequest(id_ip, uint8_t* data, uint16_t len, cbTransaction cb = nullptr, uint8_t unit = MODBUSIP_UNIT);
-uint16_t rawResponce(id_ip, uint8_t* data, uint16_t len, uint8_t unit = MODBUSIP_UNIT);
-uint16_t errorResponce(id_ip, Modbus::FunctionCode fn, Modbus::ResultCode excode, uint8_t unit = MODBUSIP_UNIT);
+uint16_t rawResponse(id_ip, uint8_t* data, uint16_t len, uint8_t unit = MODBUSIP_UNIT);
+uint16_t errorResponse(id_ip, Modbus::FunctionCode fn, Modbus::ResultCode excode, uint8_t unit = MODBUSIP_UNIT);
 ```
 - `id_ip` SlaveId (`uint8_t`) or server IP address (`IPAddress`)
 - `data` Pointer to data buffer to send
 - `len` Byte count to send
 - `unit` UnitId (ModbusTCP/TLS only)
-- `fn` function code in responce
-- `excode` Exception code in responce
+- `fn` function code in response
+- `excode` Exception code in response
 
 ```c
 uint16_t setTransactionId(uint16_t id);
@@ -36,7 +36,7 @@ uint16_t setTransactionId(uint16_t id);
 ```c
 union frame_arg_t {
 struct frame_arg_t {
-    bool to_server; // true if frame is responce for local Modbus server/slave
+    bool to_server; // true if frame is response for local Modbus server/slave
     union {
         // For ModbusRTU
 		uint8_t slaveId;

--- a/examples/Bridge/TCP-to-RTU-Simulator/TCP-to-RTU-Simulator.ino
+++ b/examples/Bridge/TCP-to-RTU-Simulator/TCP-to-RTU-Simulator.ino
@@ -58,17 +58,17 @@ Modbus::ResultCode cbTcpRaw(uint8_t* data, uint8_t len, void* custom) {
   Serial.print(IPAddress(src->ipaddr));
   Serial.printf(" Fn: %02X, len: %d \n\r", data[0], len);
 
-  if (transRunning) { // Note that we can't process new requests from TCP-side while waiting for responce from RTU-side.
+  if (transRunning) { // Note that we can't process new requests from TCP-side while waiting for response from RTU-side.
     tcp.setTransactionId(src->transactionId); // Set transaction id as per incoming request
-    tcp.errorResponce(IPAddress((src->ipaddr), (Modbus::FunctionCode)data[0], Modbus::EX_SLAVE_DEVICE_BUSY);
+    tcp.errorResponse(IPAddress((src->ipaddr), (Modbus::FunctionCode)data[0], Modbus::EX_SLAVE_DEVICE_BUSY);
     return Modbus::EX_SLAVE_DEVICE_BUSY;
   }
 
   rtu.rawRequest(src->unitId, data, len, cbRtuTrans);
   
-  if (!src->unitId) { // If broadcast request (no responce from slave is expected)
+  if (!src->unitId) { // If broadcast request (no response from slave is expected)
     tcp.setTransactionId(src->transactionId); // Set transaction id as per incoming request
-    tcp.errorResponce(IPAddress(src->ipaddr), (Modbus::FunctionCode)data[0], Modbus::EX_ACKNOWLEDGE);
+    tcp.errorResponse(IPAddress(src->ipaddr), (Modbus::FunctionCode)data[0], Modbus::EX_ACKNOWLEDGE);
 
     transRunning = 0;
     slaveRunning = 0;
@@ -92,7 +92,7 @@ Modbus::ResultCode cbRtuRaw(uint8_t* data, uint8_t len, void* custom) {
   if (!transRunning) // Unexpected incoming data
       return Modbus::EX_PASSTHROUGH;
   tcp.setTransactionId(transRunning); // Set transaction id as per incoming request
-  uint16_t succeed = tcp.rawResponce(srcIp, data, len, slaveRunning);
+  uint16_t succeed = tcp.rawResponse(srcIp, data, len, slaveRunning);
   if (!succeed){
     Serial.print("TCP IP out - failed");
   }

--- a/examples/Bridge/true/true.ino
+++ b/examples/Bridge/true/true.ino
@@ -47,7 +47,7 @@ Modbus::ResultCode cbTcpRaw(uint8_t* data, uint8_t len, void* custom) {
   Serial.print(IPAddress(src->ipaddr));
   Serial.printf(" Fn: %02X, len: %d \n", data[0], len);
   if (!src->to_server && transRunning == src->transactionId) { // Check if transaction id is match
-    rtu.rawResponce(slaveRunning, data, len);
+    rtu.rawResponse(slaveRunning, data, len);
   } else
     return Modbus::EX_PASSTHROUGH; // Allow frame to be processed by generic ModbusTCP routines
   transRunning = 0;
@@ -66,19 +66,19 @@ Modbus::ResultCode cbRtuRaw(uint8_t* data, uint8_t len, void* custom) {
       if (!tcp.connect(it->ip)) {                                                                           // Try to connect if not
         Serial.printf("error: Connection timeout\n");
        
-        rtu.errorResponce(it->slaveId, (Modbus::FunctionCode)data[0], Modbus::EX_DEVICE_FAILED_TO_RESPOND); // Send exceprional responce to master if no connection established
+        rtu.errorResponse(it->slaveId, (Modbus::FunctionCode)data[0], Modbus::EX_DEVICE_FAILED_TO_RESPOND); // Send exceprional response to master if no connection established
         // Note:
         // Indeed if both sides is build with the Modbus library _default settings_ RTU master side initiating requests to bridge will respond EX_TIMEOUT not EX_DEVICE_FAILED_TO_RESPOND.
-        // That's because connection timeout and RTU responce timeout are the same (1 second). That case EX_TIMEOUT on reached prior getting EX_DEVICE_FAILED_TO_RESPOND frame.
+        // That's because connection timeout and RTU response timeout are the same (1 second). That case EX_TIMEOUT on reached prior getting EX_DEVICE_FAILED_TO_RESPOND frame.
         return Modbus::EX_DEVICE_FAILED_TO_RESPOND; // Stop processing the frame
       }
     }
-    // Save transaction ans slave it for responce processing
+    // Save transaction ans slave it for response processing
     transRunning = tcp.rawRequest(it->ip, data, len, cbTcpTrans, it->unitId);
     if (!transRunning) {                                                                                  // rawRequest returns 0 is unable to send data for some reason
       tcp.disconnect(it->ip);                                                                             // Close TCP connection that case
       Serial.printf("send failed\n");
-      rtu.errorResponce(it->slaveId, (Modbus::FunctionCode)data[0], Modbus::EX_DEVICE_FAILED_TO_RESPOND); // Send exceprional responce to master if request bridging failed
+      rtu.errorResponse(it->slaveId, (Modbus::FunctionCode)data[0], Modbus::EX_DEVICE_FAILED_TO_RESPOND); // Send exceprional response to master if request bridging failed
       return Modbus::EX_DEVICE_FAILED_TO_RESPOND; // Stop processing the frame
     }
     Serial.printf("transaction: %d\n", transRunning);

--- a/examples/TCP-ESP/README.md
+++ b/examples/TCP-ESP/README.md
@@ -46,7 +46,7 @@ uint16_t readIreg(IPAddress ip, uint16_t offset, uint16_t* value, uint16_t numre
 
 Sends corresponding Modbus read request to Modbus server at `ip`. Connection with server shoud be already established by connect(ip).
 Returns transaction `id` or `0` on failure. Failure maens that client unable to send the request bacause of no connection to the Modbus server is established or other internal error.
-Note: read/write functions just sending requests to remote Modbus server. The functions returns immediate after request sent and doesn't waiting for result. That is `value` contains no result data on the function exit. `value` will be filled as responce arrive and processed by .task() function.
+Note: read/write functions just sending requests to remote Modbus server. The functions returns immediate after request sent and doesn't waiting for result. That is `value` contains no result data on the function exit. `value` will be filled as response arrive and processed by .task() function.
 
 ```c
 bool isTransaction(uint16_t id);

--- a/examples/TCP-ESP/clientSync/clientSync.ino
+++ b/examples/TCP-ESP/clientSync/clientSync.ino
@@ -47,7 +47,7 @@ void loop() {
       mb.task();
       delay(10);
     }
-    Serial.println(res);          // At this point res is filled with responce value
+    Serial.println(res);          // At this point res is filled with response value
   } else {
     mb.connect(remote);           // Try to connect if no connection
   }

--- a/resources/client.uml
+++ b/resources/client.uml
@@ -8,11 +8,11 @@ endif
 }
 while (request is active)
 partition task() {
-if (responce arrived) then (yes)
+if (response arrived) then (yes)
   #palegreen:Execute Transactional Callback;
   :fill result data;
 endif
-if (responce timeout) then (yes)
+if (response timeout) then (yes)
   #palegreen:Execute Transactional Callback;
 endif
 }

--- a/resources/server.uml
+++ b/resources/server.uml
@@ -6,7 +6,7 @@ if (valid request arrived) then (yes)
   #palegreen:Execute onRequest Callback;
   if (EX_SUCCESS) then (yes)
     if (correct request parameters) then (yes)
-      :Preapre responce;
+      :Preapre response;
       #palegreen:Execute onGet/onSet Callback for each register in request;
       #palegreen:Execute onRequestSuccess Callback;
     else (no)

--- a/src/Modbus.cpp
+++ b/src/Modbus.cpp
@@ -193,7 +193,7 @@ void Modbus::slavePDU(uint8_t* frame) {
                 exceptionResponse(fcode, EX_SLAVE_FAILURE);
                 return;
             }
-            successResponce(HREG(field1), field2, fcode);
+            successResponse(HREG(field1), field2, fcode);
             _reply = REPLY_NORMAL;
             _onRequestSuccess(fcode, {HREG(field1), field2});
         break;
@@ -289,7 +289,7 @@ void Modbus::slavePDU(uint8_t* frame) {
                 exceptionResponse(fcode, EX_SLAVE_FAILURE);
                 return;
             }
-            successResponce(COIL(field1), field2, fcode);
+            successResponse(COIL(field1), field2, fcode);
             _reply = REPLY_NORMAL;
             _onRequestSuccess(fcode, {COIL(field1), field2});
         break;
@@ -436,7 +436,7 @@ void Modbus::slavePDU(uint8_t* frame) {
     }
 }
 
-void Modbus::successResponce(TAddress startreg, uint16_t numoutputs, FunctionCode fn) {
+void Modbus::successResponse(TAddress startreg, uint16_t numoutputs, FunctionCode fn) {
     free(_frame);
 	_len = 5;
     _frame = (uint8_t*) malloc(_len);
@@ -742,11 +742,11 @@ void Modbus::bitsToBool(bool* dst, uint8_t* src, uint16_t numregs) {
 
 void Modbus::masterPDU(uint8_t* frame, uint8_t* sourceFrame, TAddress startreg, uint8_t* output) {
     uint8_t fcode  = frame[0];
-    if ((fcode & 0x80) != 0) { // Check if error responce
+    if ((fcode & 0x80) != 0) { // Check if error response
 	    _reply = frame[1];
 	    return;
     }
-    if (fcode != sourceFrame[0]) { // Check if responce matches the request
+    if (fcode != sourceFrame[0]) { // Check if response matches the request
         _reply = EX_DATA_MISMACH;
         return;
     }

--- a/src/Modbus.h
+++ b/src/Modbus.h
@@ -257,6 +257,11 @@ class Modbus {
         virtual TRegister* searchRegister(TAddress addr);
         void exceptionResponse(FunctionCode fn, ResultCode excode); // Fills _frame with response
         void successResponse(TAddress startreg, uint16_t numoutputs, FunctionCode fn);  // Fills frame with response
+        // Use `successResponse` instead
+        [[deprecated]]
+        void successResponce(TAddress startreg, uint16_t numoutputs, FunctionCode fn) {
+            successResponse(startreg, numoutputs, fn);
+        }
         void slavePDU(uint8_t* frame);    //For Slave
         void masterPDU(uint8_t* frame, uint8_t* sourceFrame, TAddress startreg, uint8_t* output = nullptr);   //For Master
         // frame - data received form slave

--- a/src/Modbus.h
+++ b/src/Modbus.h
@@ -30,7 +30,7 @@ static inline uint16_t __swap_16(uint16_t num) { return (num >> 8) | (num << 8);
 #define ISTS_VAL(v) (v?0xFF00:0x0000)
 #define ISTS_BOOL(v) (v==0xFF00)
 
-// For depricated (v1.xx) onSet/onGet format compatibility
+// For deprecated (v1.xx) onSet/onGet format compatibility
 #define cbDefault nullptr
 
 struct TRegister;
@@ -116,7 +116,7 @@ class Modbus {
             FC_READWRITE_REGS   = 0x17  // Read/Write Multiple registers
         };
         //Exception Codes
-        //Custom result codes used internally and for callbacks but never used for Modbus responce
+        //Custom result codes used internally and for callbacks but never used for Modbus response
         enum ResultCode {
             EX_SUCCESS              = 0x00, // Custom. No error
             EX_ILLEGAL_FUNCTION     = 0x01, // Function Code not Supported
@@ -256,7 +256,7 @@ class Modbus {
         uint16_t callback(TRegister* reg, uint16_t val, TCallback::CallbackType t);
         virtual TRegister* searchRegister(TAddress addr);
         void exceptionResponse(FunctionCode fn, ResultCode excode); // Fills _frame with response
-        void successResponce(TAddress startreg, uint16_t numoutputs, FunctionCode fn);  // Fills frame with response
+        void successResponse(TAddress startreg, uint16_t numoutputs, FunctionCode fn);  // Fills frame with response
         void slavePDU(uint8_t* frame);    //For Slave
         void masterPDU(uint8_t* frame, uint8_t* sourceFrame, TAddress startreg, uint8_t* output = nullptr);   //For Master
         // frame - data received form slave

--- a/src/ModbusAPI.h
+++ b/src/ModbusAPI.h
@@ -130,9 +130,9 @@ class ModbusAPI : public T {
 	template <typename TYPEID>
 	uint16_t rawRequest(TYPEID ip, uint8_t* data, uint16_t len, cbTransaction cb = nullptr, uint8_t unit = MODBUSIP_UNIT);
 	template <typename TYPEID>
-	uint16_t rawResponce(TYPEID ip, uint8_t* data, uint16_t len, uint8_t unit = MODBUSIP_UNIT);
+	uint16_t rawResponse(TYPEID ip, uint8_t* data, uint16_t len, uint8_t unit = MODBUSIP_UNIT);
 	template <typename TYPEID>
-	uint16_t errorResponce(TYPEID ip, Modbus::FunctionCode fn, Modbus::ResultCode excode, uint8_t unit = MODBUSIP_UNIT);
+	uint16_t errorResponse(TYPEID ip, Modbus::FunctionCode fn, Modbus::ResultCode excode, uint8_t unit = MODBUSIP_UNIT);
 };
 
 // FNAME	writeCoil, writeIsts, writeHreg, writeIreg
@@ -488,7 +488,7 @@ uint16_t ModbusAPI<T>::rawRequest(TYPEID ip, \
 
 template <class T>
 template <typename TYPEID>
-uint16_t ModbusAPI<T>::rawResponce(TYPEID ip, \
+uint16_t ModbusAPI<T>::rawResponse(TYPEID ip, \
 			uint8_t* data, uint16_t len, uint8_t unit) {
 	free(this->_frame);
 	this->_frame = (uint8_t*)malloc(len);
@@ -501,7 +501,7 @@ uint16_t ModbusAPI<T>::rawResponce(TYPEID ip, \
 
 template <class T>
 template <typename TYPEID>
-uint16_t ModbusAPI<T>::errorResponce(TYPEID ip, Modbus::FunctionCode fn, Modbus::ResultCode excode, uint8_t unit) {
+uint16_t ModbusAPI<T>::errorResponse(TYPEID ip, Modbus::FunctionCode fn, Modbus::ResultCode excode, uint8_t unit) {
 	this->exceptionResponse(fn, excode);
 	return this->send(ip, NULLREG, nullptr, unit, nullptr, false);
 }

--- a/src/ModbusAPI.h
+++ b/src/ModbusAPI.h
@@ -133,6 +133,19 @@ class ModbusAPI : public T {
 	uint16_t rawResponse(TYPEID ip, uint8_t* data, uint16_t len, uint8_t unit = MODBUSIP_UNIT);
 	template <typename TYPEID>
 	uint16_t errorResponse(TYPEID ip, Modbus::FunctionCode fn, Modbus::ResultCode excode, uint8_t unit = MODBUSIP_UNIT);
+
+	// Use `rawResponse` instead
+	template <typename TYPEID>
+	[[deprecated]]
+	uint16_t rawResponce(TYPEID ip, uint8_t* data, uint16_t len, uint8_t unit = MODBUSIP_UNIT) {
+		return rawResponse(ip, data, len, unit);
+	}
+	// Use `errorResponse` instead
+	template <typename TYPEID>
+	[[deprecated]]
+	uint16_t errorResponce(TYPEID ip, Modbus::FunctionCode fn, Modbus::ResultCode excode, uint8_t unit = MODBUSIP_UNIT) {
+		return errorResponce(ip, fn, excode, unit);
+	}
 };
 
 // FNAME	writeCoil, writeIsts, writeHreg, writeIreg

--- a/src/ModbusRTU.cpp
+++ b/src/ModbusRTU.cpp
@@ -71,7 +71,7 @@ uint32_t ModbusRTUTemplate::charSendTime(uint32_t baud, uint8_t char_bits) {
 
 uint32_t ModbusRTUTemplate::calculateMinimumInterFrameTime(uint32_t baud, uint8_t char_bits) {
 	// baud = baudrate of the serial port
-	// char_bits = size of 1 modbus character (defined a 11 bits in modbus specificacion)
+	// char_bits = size of 1 modbus character (defined a 11 bits in modbus specification)
 	// Returns: The minimum time between frames (defined as 3.5 characters time in modbus specification)
 	
 	// According to standard, the Modbus frame is always 11 bits long:
@@ -104,7 +104,7 @@ void ModbusRTUTemplate::setInterFrameTime(uint32_t t_us) {
 	// If the interframe calculated by calculateMinimumInterFrameTime() is not enough, you can set the interframe time manually with this function. 
 	// The time must be set in micro seconds. 
 	// This is useful when you are receiving data as a slave and you notice that the slave is dividing a frame in two or more pieces (and obviously the CRC is failing on all pieces).
-	// This is because it is detecting an interframe time inbetween bytes of the frame and thus it interprets one single frame as two or more frames.
+	// This is because it is detecting an interframe time in between bytes of the frame and thus it interprets one single frame as two or more frames.
 	// In that case it is useful to be able to set a more "permissive" interframe time.
     _t = t_us;
 }
@@ -267,7 +267,7 @@ void ModbusRTUTemplate::task() {
 	Serial.println();
 	#endif
 	//_port->readBytes(_frame, _len);
-    uint16_t frameCrc = ((_frame[_len - 2] << 8) | _frame[_len - 1]); // Last two byts = crc
+    uint16_t frameCrc = ((_frame[_len - 2] << 8) | _frame[_len - 1]); // Last two bytes = crc
     _len = _len - 2;    // Decrease by CRC 2 bytes
     if (frameCrc != crc16(address, _frame, _len)) {  // CRC Check
 		goto cleanup;
@@ -282,7 +282,7 @@ void ModbusRTUTemplate::task() {
 	}
     if (isMaster) {
         if ((_frame[0] & 0x7F) == _sentFrame[0]) { // Check if function code the same as requested
-			// Procass incoming frame as master
+			// Process incoming frame as master
 			if (_reply == EX_PASSTHROUGH || _reply == EX_FORCE_PROCESS)
 				masterPDU(_frame, _sentFrame, _sentReg, _data);
             if (_cb) {

--- a/src/ModbusSettings.h
+++ b/src/ModbusSettings.h
@@ -43,7 +43,7 @@ If defined C STL will be used.
 
 /*
 #define MODBUS_MAX_REGS     32
-If defined regisers count will be limited.
+If defined registers count will be limited.
 */
 // Add limitation for specific STL implementation
 #if defined(MODBUS_USE_STL) && (defined(ESP8266) || defined(ESP32))
@@ -117,8 +117,8 @@ Enable using separate pins for RE DE
 #define MODBUSRTU_MAX_READ_US 1000UL * MODBUSRTU_MAX_READMS
 
 /*
-#defone MODBUSRTU_FLUSH_DELAY 1
-Set extraa delay after serial buffer flush before changing RE/DE pin state.
+#define MODBUSRTU_FLUSH_DELAY 1
+Set extra delay after serial buffer flush before changing RE/DE pin state.
 Specified in chars. That is 1 is means to add delay enough to send 1 char at current port baudrate
 */
 //#define MODBUSRTU_FLUSH_DELAY 1

--- a/src/ModbusTCPTemplate.h
+++ b/src/ModbusTCPTemplate.h
@@ -104,10 +104,10 @@ class ModbusTCPTemplate : public Modbus {
 	bool disconnect(IPAddress ip);
 	// ModbusTCP
 	void server(uint16_t port = 0);
-	// ModbusTCP depricated
-	inline void slave(uint16_t port = 0) { server(port); }	// Depricated
-	inline void master() { client(); }	// Depricated
-	inline void begin() { server(); }; 	// Depricated
+	// ModbusTCP deprecated
+	inline void slave(uint16_t port = 0) { server(port); }	// Deprecated
+	inline void master() { client(); }	// Deprecated
+	inline void begin() { server(); }; 	// Deprecated
 	void client();
 	void task();
 	void onConnect(cbModbusConnect cb = nullptr);
@@ -349,7 +349,7 @@ void ModbusTCPTemplate<SERVER, CLIENT>::task() {
 					}
 				}
 			}
-			if (!BIT_CHECK(tcpServerConnection, n)) _reply = REPLY_OFF;	// No replay if it was responce to master
+			if (!BIT_CHECK(tcpServerConnection, n)) _reply = REPLY_OFF;	// No replay if it was response to master
 			if (_reply != REPLY_OFF) {
 				_MBAP.length = __swap_16(_len+1);     // _len+1 for last byte from MBAP					
 				size_t send_len = (uint16_t)_len + sizeof(_MBAP.raw);


### PR DESCRIPTION
Hello,
Thanks for this awesome library! It is working perfectly on both ESP8266 and ESP32 cores, so probably it deserves a rename.

However the "responce" typo just let me down a bit, especially since it is quite prominent since exposed in the API.
What about a rename? I know that this will change the API, so probably you will be interested in maintaining the backward compatibility.
Please let me know if you want to do that, eventually with the usage of `__attribute__((deprecated))` in order to raise warnings at compile time.

A whole next level change would be to rename the methods to drop the master/slave naming in favor of client/server (see [here](https://modbus.org/docs/Client-ServerPR-07-2020-final.docx.pdf)], but I noticed there is always something going on, even if is not super-clear to me (it looks inverted in the RTU interface?):
```cpp
	void client() { isMaster = true; };
	inline void master() {client();}
	void server(uint8_t serverId) {_slaveId = serverId;};
	inline void slave(uint8_t slaveId) {server(slaveId);}
	uint8_t server() { return _slaveId; }
	inline uint8_t slave() { return server(); }
```

Thanks! 
 L