### PR TITLE
- Enum-based TX enable mode

### DIFF
--- a/documentation/API.md
+++ b/documentation/API.md
@@ -47,12 +47,12 @@ bool removeIreg(uint16_t offset, uint16_t numregs = 1);
 ### Modbus RTU Specific API
 
 ```c
-bool begin(SoftwareSerial* port, int16_t txEnablePin=-1, bool txEnableDirect=true);
-bool begin(HardwareSerial* port, int16_t txEnablePin=-1, bool txEnableDirect=true);
+bool begin(SoftwareSerial* port, int16_t txEnablePin=-1, ModbusRTUTxEnableMode txEnableMode=TxEnableHigh);
+bool begin(HardwareSerial* port, int16_t txEnablePin=-1, ModbusRTUTxEnableMode txEnableMode=TxEnableHigh);
 bool begin(Stream* port);
 ```
 
-Assing Serial port. txEnablePin controls transmit enable for MAX-485. Pass txEnableDirect=false if txEnablePin uses inverse logic.
+Assign Serial port. `txEnablePin` controls transmit enable for MAX-485. Use `txEnableMode = TxEnableLow` if `txEnablePin` uses inverse logic (low when transmitting).
 
 ```c
 void setBaudrte(uint32 baud);

--- a/examples/RTU/README.MD
+++ b/examples/RTU/README.MD
@@ -11,14 +11,14 @@ This example introduces how to use the library for ModbusRTU (typicaly over RS-4
 ## Modbus RTU Specific API
 
 ```c
-bool begin(SoftwareSerial* port, int16_t txEnablePin=-1, bool txEnableDirect=true);
-bool begin(HardwareSerial* port, int16_t txEnablePin=-1, bool txEnableDirect=true);
+bool begin(SoftwareSerial* port, int16_t txEnablePin=-1, ModbusRTUTxEnableMode txEnableMode=TxEnableHigh);
+bool begin(HardwareSerial* port, int16_t txEnablePin=-1, ModbusRTUTxEnableMode txEnableMode=TxEnableHigh);
 bool begin(Stream* port);
 ```
 
 - `port`    Pointer to Serial port
 - `txEnablePin`   RX/TX control pin. Not assigned (assume auto RX/TX) by default
-- `txEnableDirect`  Direct (true, default) or inverse (false) RX/TX pin control.
+- `txEnablePin` controls transmit enable for MAX-485. Use `txEnableMode = TxEnableLow` if `txEnablePin` uses inverse logic (low when transmitting).
 
 Assign Serial port. txEnablePin controls transmit enable for MAX-485.
 

--- a/src/ModbusRTU.cpp
+++ b/src/ModbusRTU.cpp
@@ -109,7 +109,7 @@ void ModbusRTUTemplate::setInterFrameTime(uint32_t t_us) {
     _t = t_us;
 }
 
-bool ModbusRTUTemplate::begin(Stream* port, int16_t txEnablePin, bool txEnableDirect) {
+bool ModbusRTUTemplate::begin(Stream* port, int16_t txEnablePin, ModbusRTUTxEnableMode txEnableMode) {
     _port = port;
     _t = 1750UL;
 #if defined(MODBUSRTU_FLUSH_DELAY)
@@ -117,9 +117,9 @@ bool ModbusRTUTemplate::begin(Stream* port, int16_t txEnablePin, bool txEnableDi
 #endif
     if (txEnablePin >= 0) {
 	    _txEnablePin = txEnablePin;
-		_direct = txEnableDirect;
+		_txEnableMode = txEnableMode;
         pinMode(_txEnablePin, OUTPUT);
-        digitalWrite(_txEnablePin, _direct?LOW:HIGH);
+        digitalWrite(_txEnablePin, _txEnableMode == TxEnableHigh ? LOW : HIGH);
     }
     return true;
 }
@@ -136,16 +136,16 @@ bool ModbusRTUTemplate::rawSend(uint8_t slaveId, uint8_t* frame, uint8_t len) {
 #if defined(MODBUSRTU_REDE)
 	if (_txEnablePin >= 0 || _rxPin >= 0) {
     	if (_txEnablePin >= 0)
-        	digitalWrite(_txEnablePin, _direct?HIGH:LOW);
+        	digitalWrite(_txEnablePin, _txEnableMode == TxEnableHigh ? HIGH : LOW);
 		if (_rxPin >= 0)
-        	digitalWrite(_rxPin, _direct?HIGH:LOW);
+        	digitalWrite(_rxPin, _txEnableMode == TxEnableHigh ? HIGH : LOW);
 #if !defined(ESP32)
         delayMicroseconds(MODBUSRTU_REDE_SWITCH_US);
 #endif
 	}
 #else
     if (_txEnablePin >= 0) {
-        digitalWrite(_txEnablePin, _direct?HIGH:LOW);
+        digitalWrite(_txEnablePin, _txEnableMode == TxEnableHigh ? HIGH : LOW);
 #if !defined(ESP32)
         delayMicroseconds(MODBUSRTU_REDE_SWITCH_US);
 #endif
@@ -165,16 +165,16 @@ bool ModbusRTUTemplate::rawSend(uint8_t slaveId, uint8_t* frame, uint8_t len) {
 		delayMicroseconds(_t1 * MODBUSRTU_FLUSH_DELAY);
 #endif
     	if (_txEnablePin >= 0)
-        	digitalWrite(_txEnablePin, _direct?LOW:HIGH);
+        	digitalWrite(_txEnablePin, _txEnableMode == TxEnableHigh ? LOW : HIGH);
 		if (_rxPin >= 0)
-        	digitalWrite(_rxPin, _direct?LOW:HIGH);
+        	digitalWrite(_rxPin, _txEnableMode == TxEnableHigh ? LOW : HIGH);
 	}
 #else
     if (_txEnablePin >= 0) {
 #if defined(MODBUSRTU_FLUSH_DELAY)
 		delayMicroseconds(_t1 * MODBUSRTU_FLUSH_DELAY);
 #endif
-        digitalWrite(_txEnablePin, _direct?LOW:HIGH);
+        digitalWrite(_txEnablePin, _txEnableMode == TxEnableHigh ? LOW : HIGH);
 	}
 #endif
     return true;

--- a/src/ModbusRTU.h
+++ b/src/ModbusRTU.h
@@ -61,13 +61,33 @@ class ModbusRTUTemplate : public Modbus {
 		uint32_t calculateMinimumInterFrameTime(uint32_t baud, uint8_t char_bits = 11);
 		void setInterFrameTime(uint32_t t_us);
 		uint32_t charSendTime(uint32_t baud, uint8_t char_bits = 11);
+
+		// Use `ModbusRTUTxEnableMode` overload instead
+		template <class T>
+		[[deprecated]]
+		bool begin(T* port, int16_t txEnablePin = -1, bool txEnableDirect = true) {
+			return begin(port, txEnablePin, txEnableDirect ? TxEnableHigh : TxEnableLow);
+		}
 		template <class T>
 		bool begin(T* port, int16_t txEnablePin = -1, ModbusRTUTxEnableMode txEnableMode = TxEnableHigh);
+
 #if defined(MODBUSRTU_REDE)
+		// Use `ModbusRTUTxEnableMode` overload instead
+		template <class T>
+		[[deprecated]]
+		bool begin(T* port, int16_t txEnablePin, int16_t rxEnablePin, bool txEnableDirect) {
+			return begin(port, txEnablePin, rxEnablePin, txEnableDirect ? TxEnableHigh : TxEnableLow);
+		}
 		template <class T>
 		bool begin(T* port, int16_t txEnablePin, int16_t rxEnablePin, ModbusRTUTxEnableMode txEnableMode);
 #endif
+		// Use `ModbusRTUTxEnableMode` overload instead
+		[[deprecated]]
+		bool begin(Stream* port, int16_t txEnablePin = -1, bool txEnableDirect = true) {
+			return begin(port, txEnablePin, txEnableDirect ? TxEnableHigh : TxEnableLow);
+		}
 		bool begin(Stream* port, int16_t txEnablePin = -1, ModbusRTUTxEnableMode txEnableMode = TxEnableHigh);
+
         void task();
 		void client() { isMaster = true; };
 		inline void master() {client();}


### PR DESCRIPTION
Hello,
It is probably better to introduce an enum-based value for the current `txEnableDirect`, to have a more self-explaining API, not requiring to look at the documentation to understand what really 'direct' mean in logic terms (e.g. from an electronic point of view, usually levels are negated, so 'direct' can be quite confusing here).

What do you think about it?
Thx! L