### PR TITLE
- Added flag to receive packets with invalid CRC as well

### DIFF
--- a/src/Modbus.h
+++ b/src/Modbus.h
@@ -173,16 +173,22 @@ class Modbus {
 	    struct frame_arg_t {
             bool to_server;
             union {
-		        uint8_t slaveId;
+                // For RTU
+                struct {
+		            uint8_t slaveId;
+                    bool validFrame;
+                };
+                // For TCP
 		        struct {
 			        uint8_t unitId;
 			        uint32_t ipaddr;
 			        uint16_t transactionId;
 		        };
             };
-            frame_arg_t(uint8_t s, bool m = false) {
-                slaveId = s;
-                to_server = m;
+            frame_arg_t(uint8_t _slaveId, bool _to_server = false, bool _validFrame = true) {
+                slaveId = _slaveId;
+                to_server = _to_server;
+                validFrame = _validFrame;
             };
             frame_arg_t(uint8_t u, uint32_t a, uint16_t t, bool m = false) {
                 unitId = u;

--- a/src/ModbusRTU.h
+++ b/src/ModbusRTU.h
@@ -30,6 +30,7 @@ class ModbusRTUTemplate : public Modbus {
 		TAddress _sentReg = COIL(0);
 		uint16_t maxRegs = MODBUS_MAX_WORDS;
 		uint8_t address = 0;
+		bool _cbRawIncludeCrcErrors = false;
 
 		uint16_t send(uint8_t slaveId, TAddress startreg, cbTransaction cb, uint8_t unit = MODBUSIP_UNIT, uint8_t* data = nullptr, bool waitResponse = true);
 		// Prepare and send ModbusRTU frame. _frame buffer and _len should be filled with Modbus data
@@ -61,6 +62,8 @@ class ModbusRTUTemplate : public Modbus {
 		uint8_t server() { return _slaveId; }
 		inline uint8_t slave() { return server(); }
 		uint32_t eventSource() override {return address;}
+		// Overload
+        bool onRaw(cbRaw cb = nullptr, bool includeCrcErrors = false);
 };
 
 template <class T>


### PR DESCRIPTION
Hi,
I'm coping right now with a brand new solar inverter that pretends to talk Modbus on RS485. However, if I invoke function 0x3 to read registers and an invalid range is specified (the addressing seems to be split in many different sub-ranges), instead of answering:

```
[0x01] [0x83] [0x02] [CRC] [CRC]
```  

(where 0x1 is obviously the node Id), it always wrongly respond with:

```
[0x01] [0x90] [0x02] [0x00] [0x00]
```  

with two errors: respond to the function 0x10 + error flag, rather than the 0x3, and it fails to present a valid CRC, the two bytes are _always_ zero.
I'm not sure if this is a firmware issue that will be corrected in the future, or if it is part of a some non-standard code.

However, I was interested in receiving such strange errors and process them correctly. Currently, the library rejects the packet due to CRC error.

The idea is to be able to receive malformed packet (I can see there is already a partial support there). However, for compatibility, I suggest to add a new argument to the `onRaw`, in order to specify the willing to receive also CRC-failed packets.

In addition, I added a `validFrame` boolean flag in the `frame_arg_t` argument, that is not set in case of CRC errors or in the previously covered cases of wrong node id.

I separated the `onRaw` of the base class, used by the TCP implementation, since CRC is only on the RTU side.

Please let me know what you think about it.
Thanks! L.


