### PR TITLE
- delayMicroseconds and standard TCP APIs now available in both cores

### DIFF
--- a/src/ModbusRTU.cpp
+++ b/src/ModbusRTU.cpp
@@ -139,16 +139,12 @@ bool ModbusRTUTemplate::rawSend(uint8_t slaveId, uint8_t* frame, uint8_t len) {
         	digitalWrite(_txEnablePin, _direct?HIGH:LOW);
 		if (_rxPin >= 0)
         	digitalWrite(_rxPin, _direct?HIGH:LOW);
-#if !defined(ESP32)
         delayMicroseconds(MODBUSRTU_REDE_SWITCH_US);
-#endif
 	}
 #else
     if (_txEnablePin >= 0) {
         digitalWrite(_txEnablePin, _direct?HIGH:LOW);
-#if !defined(ESP32)
         delayMicroseconds(MODBUSRTU_REDE_SWITCH_US);
-#endif
 	}
 #endif
 #if defined(ESP32)

--- a/src/ModbusTCP.h
+++ b/src/ModbusTCP.h
@@ -14,15 +14,7 @@
 #include "ModbusAPI.h"
 #include "ModbusTCPTemplate.h"
 
-class WiFiServerESPWrapper : public WiFiServer {
-  public:
-    WiFiServerESPWrapper(uint16_t port) : WiFiServer(port) {}
-    inline WiFiClient accept() {
-        return available();
-    }
-};
-
-class ModbusTCP : public ModbusAPI<ModbusTCPTemplate<WiFiServerESPWrapper, WiFiClient>> {
+class ModbusTCP : public ModbusAPI<ModbusTCPTemplate<WiFiServer, WiFiClient>> {
 #if defined(MODBUSIP_USE_DNS)
   private:
     static IPAddress resolver(const char *host) {


### PR DESCRIPTION
One of the two TX delay was wrongly commented out in case of ESP32, probably because the call was missing.
Removed also the `WiFiServerESPWrapper`, since now in both ESP32 and ESP8266 cores the `accept` is there.
Thx, L