### PR TITLE
- Allow to change MODBUSRTU_TIMEOUT from project

### DIFF
--- a/src/ModbusSettings.h
+++ b/src/ModbusSettings.h
@@ -104,7 +104,9 @@ Otherwise IP addresses only must be used
 #define MODBUSRTU_BROADCAST 0
 #define MB_RESERVE 248
 #define MB_SERIAL_BUFFER 128
+#ifndef MODBUSRTU_TIMEOUT
 #define MODBUSRTU_TIMEOUT 1000
+#endif
 #define MODBUSRTU_MAX_READMS 100
 /*
 #define MODBUSRTU_REDE


### PR DESCRIPTION
With this simple change, it will be possible to override the RTU timeout from compiler flags (-DMODBUSRTU_TIMEOUT).
Trying to implement a shorter RTU timeout from the applicative code won't work in primary mode, since the `cleanup()` call is protected: without this call the internal state will remain in listening mode and it will discard any additional send.
Thanks!
 L 