### PR TITLE
- Fixed error recovery

### DIFF
--- a/src/ModbusRTU.cpp
+++ b/src/ModbusRTU.cpp
@@ -309,6 +309,7 @@ cleanup:
     free(_frame);
     _frame = nullptr;
     _len = 0;
+	_slaveId = 0;
 	if (isMaster) cleanup();
 }
 


### PR DESCRIPTION
Hi,
I've found an issue in cleaning up the RTU module state, that happens in one of the following cases of incoming packet:
- a CRC error is detected (e.g. malformed packet or transmission error due to noisy line);
- a custom `cbRaw` callback is installed and a `EX_PASSTHROUGH` is returned when the frame was not valid, but the CRC was ok;

In these cases, the state of the receiver is not correctly reset, and it is impossible to send new packets (e.g. the `send()` always returns `false`) until the timeout elapsed. This is because the `cleanup()` function only acts after `MODBUSRTU_TIMEOUT_US` timeout.

Setting `_slaveId = 0` at the end of the `task()` fixes the issue.
It is also probably better to get rid of the `goto` used in the `task()` function and linting it.

Thanks! 
 L