### PR TITLE
Update ModbusTLS.h

### DIFF
--- a/src/ModbusTLS.h
+++ b/src/ModbusTLS.h
@@ -113,12 +113,14 @@ class ModbusTLS : public ModbusAPI<ModbusTCPTemplate<WiFiServerSecure, WiFiClien
         }
         #endif
         //return tcpclient[p]->connect(ip, port);
-        if (host)
+        if (host) {
           if (!tcpclient[p]->connect(host, port))
             return false;
-        else 
+        }
+        else {
           if (!tcpclient[p]->connect(ip, port))
             return false;
+        }
         return true;
     }
 };

--- a/src/ModbusTLS.h
+++ b/src/ModbusTLS.h
@@ -86,13 +86,13 @@ class ModbusTLS : public ModbusAPI<ModbusTCPTemplate<WiFiServerSecure, WiFiClien
     #endif
 #if defined(MODBUSIP_USE_DNS)
     bool connect(String host, uint16_t port, const char* client_cert = nullptr, const char* client_private_key = nullptr, const char* ca_cert = nullptr) {
-        return connect(resolver(host.c_str()), port, client_cert, client_private_key, ca_cert);
+        return connect(resolver(host.c_str()), port, client_cert, client_private_key, ca_cert, host.c_str());
     }
     bool connect(const char* host, uint16_t port, const char* client_cert = nullptr, const char* client_private_key = nullptr, const char* ca_cert = nullptr) {
-        return connect(resolver(host), port, client_cert, client_private_key, ca_cert);
+        return connect(resolver(host), port, client_cert, client_private_key, ca_cert, host);
     }
 #endif
-    bool connect(IPAddress ip, uint16_t port, const char* client_cert = nullptr, const char* client_private_key = nullptr, const char* ca_cert = nullptr) {
+    bool connect(IPAddress ip, uint16_t port, const char* client_cert = nullptr, const char* client_private_key = nullptr, const char* ca_cert = nullptr, const char* host = nullptr) {
         if (!ip)
             return false;
         if(getSlave(ip) >= 0)
@@ -113,7 +113,11 @@ class ModbusTLS : public ModbusAPI<ModbusTCPTemplate<WiFiServerSecure, WiFiClien
         }
         #endif
         //return tcpclient[p]->connect(ip, port);
-        if (!tcpclient[p]->connect(ip, port))
+        if (host)
+          if (!tcpclient[p]->connect(host, port))
+            return false;
+        else 
+          if (!tcpclient[p]->connect(ip, port))
             return false;
         return true;
     }


### PR DESCRIPTION
# Issue
When using a hostname to connect to a TLS secured Modbus server, the hostname is resolved into an IP address by the library, which mismatches the server's subject CN field (hostname) and causes a handshake error.

# Solution
Pass host to `WiFiClientSecure->connect` without resolving it to an IPAddress.

Before the changes:
```
[1703416][V][ssl_client.cpp:62] start_ssl_client(): Free internal heap before TLS 252728
[1703416][V][ssl_client.cpp:68] start_ssl_client(): Starting socket
[1703465][V][ssl_client.cpp:146] start_ssl_client(): Seeding the random number generator
[1703466][V][ssl_client.cpp:155] start_ssl_client(): Setting up the SSL/TLS structure...
[1703470][V][ssl_client.cpp:178] start_ssl_client(): Loading CA cert
[1703479][V][ssl_client.cpp:234] start_ssl_client(): Loading CRT cert
[1703484][V][ssl_client.cpp:243] start_ssl_client(): Loading private key
[1703493][V][ssl_client.cpp:254] start_ssl_client(): Setting hostname for TLS session...
[1703496][V][ssl_client.cpp:269] start_ssl_client(): Performing the SSL/TLS handshake...
[1703575][E][ssl_client.cpp:37] _handle_error(): [start_ssl_client():273]: (-9984) X509 - Certificate verification failed, e.g. CRL, CA or signature check failed
[1703578][E][WiFiClientSecure.cpp:144] connect(): start_ssl_client: -9984
[1703586][V][ssl_client.cpp:321] stop_ssl_socket(): Cleaning SSL connection
```

After the changes:
```
[  5613][V][ssl_client.cpp:62] start_ssl_client(): Free internal heap before TLS 212840
[  5620][V][ssl_client.cpp:68] start_ssl_client(): Starting socket
[  5678][V][ssl_client.cpp:146] start_ssl_client(): Seeding the random number generator
[  5678][V][ssl_client.cpp:155] start_ssl_client(): Setting up the SSL/TLS structure...
[  5682][V][ssl_client.cpp:178] start_ssl_client(): Loading CA cert
[  5691][V][ssl_client.cpp:234] start_ssl_client(): Loading CRT cert
[  5697][V][ssl_client.cpp:243] start_ssl_client(): Loading private key
[  5705][V][ssl_client.cpp:254] start_ssl_client(): Setting hostname for TLS session...
[  5708][V][ssl_client.cpp:269] start_ssl_client(): Performing the SSL/TLS handshake...
[  5716][D][ssl_client.cpp:282] start_ssl_client(): Protocol is TLSv1.2 Ciphersuite is TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256
[  5727][D][ssl_client.cpp:284] start_ssl_client(): Record expansion is 29
[  5733][V][ssl_client.cpp:290] start_ssl_client(): Verifying peer X.509 certificate...
[  5741][V][ssl_client.cpp:298] start_ssl_client(): Certificate verified.
[  5748][V][ssl_client.cpp:313] start_ssl_client(): Free internal heap after TLS 176132
```

cert.cmd used to generate certificates on Windows:
```
set OPATH=D:\programs\OpenSSL-Win64\bin

:: CN is not verified for the CA so it doesn't matter
"%OPATH%\openssl" req -new -x509 -nodes -days 365 -extensions v3_ca -keyout ca.key -out ca.crt -subj "/CN=TrustedCA.net"

:: CN is verified for the server so it must be the same as the connection host
"%OPATH%\openssl" genrsa -out server.key 2048
"%OPATH%\openssl" req -out server.csr -key server.key -new -subj "/CN=yourdomain.com"
"%OPATH%\openssl" x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 365

"%OPATH%\openssl" genrsa -out client.key 2048
"%OPATH%\openssl" req -out client.csr -key client.key -new -subj "/CN=client"
"%OPATH%\openssl" x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 365
```

Tested on ESP32 Dev Module