### PR TITLE
Update ModbusTCP.h

### DIFF
--- a/src/ModbusTCP.h
+++ b/src/ModbusTCP.h
@@ -18,7 +18,7 @@ class WiFiServerESPWrapper : public WiFiServer {
   public:
     WiFiServerESPWrapper(uint16_t port) : WiFiServer(port) {}
     inline WiFiClient accept() {
-        return available();
+        return WiFiServer::accept();
     }
 };
 


### PR DESCRIPTION
when using NodeMCU 1.0 board. - ESP8266 and latest version of WiFiManager library: 2.0.17 the message is signaled:

modbus-esp8266\src/ModbusTCP.h:21:26: warning: 'WiFiClient WiFiServer::available(uint8_t*)' is deprecated: Renamed to accept(). [-Wdeprecated-declarations]

21 | return available()

after replacing with new method: return WiFiServer::accept(); there are no error messages and communication between NodeMCU and Node-Red works, I personally tried it.